### PR TITLE
Use target size limit in strncpy() in adapter.c.

### DIFF
--- a/adapter.c
+++ b/adapter.c
@@ -507,7 +507,7 @@ static char *getAdapterConfig3 (struct adapter_config *a)
      case 4:	break;
      default:	return "invalid number of channels";
     }
-    strncpy (a->product, (char *) pinfo->product_name, sizeof (pinfo->product_name));
+    strncpy (a->product, (char *) pinfo->product_name, sizeof (a->product));
     a->product[sizeof (a->product) - 1] = '\0';
     ntrim (a->product);
     strncpy (a->bios, (char *) pinfo->bios_version, sizeof (a->bios));
@@ -665,7 +665,7 @@ static char *getAdapterConfig5 (struct adapter_config *a)
     a->dram_size = pinfo->memory_size;
 
     snprintf (a->name, sizeof (a->name), "a%u", a->target.adapno);
-    strncpy (a->product, (char *) pinfo->product_name, sizeof (pinfo->product_name));
+    strncpy (a->product, (char *) pinfo->product_name, sizeof (a->product));
     a->product[sizeof (a->product) - 1] = '\0';
     ntrim (a->product);
 


### PR DESCRIPTION
This fixes the following compiler warnings and potentially avoid a buffer overflow:

adapter.c: In function ‘getAdapterConfig3’:
adapter.c:510:63: warning: argument to ‘sizeof’ in ‘strncpy’ call is the same expression as the source; did you mean to use the size of the destination? [-Wsizeof-pointer-memaccess]
  510 |     strncpy (a->product, (char *) pinfo->product_name, sizeof (pinfo->product_name));
      |                                                               ^
adapter.c: In function ‘getAdapterConfig5’:
adapter.c:668:63: warning: argument to ‘sizeof’ in ‘strncpy’ call is the same expression as the source; did you mean to use the size of the destination? [-Wsizeof-pointer-memaccess]
  668 |     strncpy (a->product, (char *) pinfo->product_name, sizeof (pinfo->product_name));
      |                                                               ^