### PR TITLE
Added Appstream metainfo and install targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+DESTDIR=
+PREFIX=         /usr
+BINDIR=         $(PREFIX)/bin
+METAINFODIR=    $(PREFIX)/share/metainfo/
+
+INSTALL=        install
 
 SRCS=		megactl.c adapter.c megaioctl.c megatrace.c callinfo.c dumpbytes.c logpage.c ntrim.c
 INC=		-I./schily -Iincludes-hack
@@ -22,6 +28,12 @@ megasasctl.o:	megactl.c
 
 %.o:		Makefile.bak %.c
 	$(CC) $(CFLAGS) -c -o $@ $*.c
+
+install: $(PROGRAMS)
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)/
+	$(INSTALL) $(PROGRAMS) $(DESTDIR)$(BINDIR)
+	$(INSTALL) -d $(DESTDIR)$(METAINFODIR)/
+	$(INSTALL) megactl.metainfo.xml $(DESTDIR)$(METAINFODIR)/
 
 clean:
 	$(RM) $(PROGRAMS) *.o

--- a/megactl.metainfo.xml
+++ b/megactl.metainfo.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component>
+  <id>com.github.namiltd.megactl</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>megactl</name>
+  <summary>LSI Megaraid Control and Monitoring Tools</summary>
+  <description>
+    <p>
+      Provide tools to query hard drive and RAID volume status from
+      PERC2, PERC3, PERC4 and PERC5 adapters.
+    </p>
+  </description>
+  <provides>
+    <modalias>lkmodule:megaraid</modalias>
+    <modalias>lkmodule:megaraid_sas</modalias>
+    <modalias>pci:v00001000d000010E7sv*</modalias>
+    <modalias>pci:v00001000d000010E4sv*</modalias>
+    <modalias>pci:v00001000d000010E3sv*</modalias>
+    <modalias>pci:v00001000d000010E0sv*</modalias>
+    <modalias>pci:v00001000d000010E6sv*</modalias>
+    <modalias>pci:v00001000d000010E5sv*</modalias>
+    <modalias>pci:v00001000d000010E2sv*</modalias>
+    <modalias>pci:v00001000d000010E1sv*</modalias>
+    <modalias>pci:v00001000d0000001Csv*</modalias>
+    <modalias>pci:v00001000d0000001Bsv*</modalias>
+    <modalias>pci:v00001000d00000017sv*</modalias>
+    <modalias>pci:v00001000d00000016sv*</modalias>
+    <modalias>pci:v00001000d00000015sv*</modalias>
+    <modalias>pci:v00001000d00000014sv*</modalias>
+    <modalias>pci:v00001000d00000053sv*</modalias>
+    <modalias>pci:v00001000d00000052sv*</modalias>
+    <modalias>pci:v00001000d000000CFsv*</modalias>
+    <modalias>pci:v00001000d000000CEsv*</modalias>
+    <modalias>pci:v00001000d0000005Fsv*</modalias>
+    <modalias>pci:v00001000d0000005Dsv*</modalias>
+    <modalias>pci:v00001000d0000002Fsv*</modalias>
+    <modalias>pci:v00001000d0000005Bsv*</modalias>
+    <modalias>pci:v00001028d00000015sv*</modalias>
+    <modalias>pci:v00001000d00000413sv*</modalias>
+    <modalias>pci:v00001000d00000071sv*</modalias>
+    <modalias>pci:v00001000d00000073sv*</modalias>
+    <modalias>pci:v00001000d00000079sv*</modalias>
+    <modalias>pci:v00001000d00000078sv*</modalias>
+    <modalias>pci:v00001000d0000007Csv*</modalias>
+    <modalias>pci:v00001000d00000060sv*</modalias>
+    <modalias>pci:v00001000d00000411sv*</modalias>
+    <modalias>pci:v00008086d00001960sv*</modalias>
+    <modalias>pci:v0000101Ed00009060sv*</modalias>
+    <modalias>pci:v0000101Ed00009010sv*</modalias>
+  </provides>
+</component>


### PR DESCRIPTION
The Appstream metainfo format can be used to automatically map hardware to packages, and allow distributions to automatically install the metactl package on machines that could use it.

Added a 'make install' target to install programs and metainfo file in the common location.