### PR TITLE
Use correct file permissions when installing Appstream metainfo XML.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ install: $(PROGRAMS)
 	$(INSTALL) -d $(DESTDIR)$(BINDIR)/
 	$(INSTALL) $(PROGRAMS) $(DESTDIR)$(BINDIR)
 	$(INSTALL) -d $(DESTDIR)$(METAINFODIR)/
-	$(INSTALL) megactl.metainfo.xml $(DESTDIR)$(METAINFODIR)/
+	$(INSTALL) -m644 megactl.metainfo.xml $(DESTDIR)$(METAINFODIR)/
 
 clean:
 	$(RM) $(PROGRAMS) *.o


### PR DESCRIPTION
The file should not be executable, which is the default for the install program.