### PR TITLE
Extend buffer size in megaSasGetDeviceList() to avoid too small buf size.

### DIFF
--- a/megaioctl.c
+++ b/megaioctl.c
@@ -415,7 +415,7 @@ int megaGetDriveErrorCount (struct mega_adapter_path *adapter, uint8_t target, s
 
 int megaSasGetDeviceList (struct mega_adapter_path *adapter, struct mega_device_list_sas **data)
 {
-    unsigned char		buf[0x20];
+    unsigned char		buf[sizeof(struct mega_device_list_sas)];
     uint32_t			len;
 
     if (sasCommand (adapter, buf, sizeof buf, 0x02010000, MFI_FRAME_DIR_READ, NULL, 0) < 0)


### PR DESCRIPTION
This solve the following compiler warning seen when building the Debian package:

  megaioctl.c: In function ‘megaSasGetDeviceList’:
  megaioctl.c:416:48: warning: array subscript ‘struct mega_device_list_sas[0]’ is partly outside array bounds of ‘unsigned char[32]’ [-Warray-bounds]
    416 |     len = ((struct mega_device_list_sas *) buf)->length;
        |                                                ^~
  megaioctl.c:411:33: note: object ‘buf’ of size 32
    411 |     unsigned char               buf[0x20];
        |                                 ^~~